### PR TITLE
Add the migrator for line background colours

### DIFF
--- a/v2/migrator/migrations_list.js
+++ b/v2/migrator/migrations_list.js
@@ -17,6 +17,7 @@ const list = [
   'm2020_8_28',
   'm2020_11_16',
   'm2021_1_15',
+  'm2021_1_23',
 ]
 
 export default list


### PR DESCRIPTION
# Motivation
To get the add card split button (one half is the control for using a template and the other half creates a default blank card) right, we need some way to specify the background colour.
If we use the card colour, it's too strong on the UI, and the text doesn't contrast enough.

Background colours were added in a previous pull request.
This pull request adds the migrator for the background colour to the list of migrators to run.