### PR TITLE
Make plottr_locales a file-system peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "slate-hyperscript": "^0.57.1",
     "tinycolor2": "^1.4.2"
   },
-  "peerDependencies": {
-    "plottr_locales": "0.0.1"
+  "devDependencies": {
+    "plottr_locales": "file:../plottr_locales"
   }
 }


### PR DESCRIPTION
# Move plottr_locales to a File Dependency
Move the dependency on plottr_locales to a file-system peer dependency.
The idea behind this is that you can work on the libraries outside of a projects lib folder as long as it has its Plottr dependencies as peers in the folder that this repo.