### PR TITLE
Upstream changes from plottr web

### DIFF
--- a/v2/actions/featureFlags.js
+++ b/v2/actions/featureFlags.js
@@ -15,7 +15,7 @@ export const setBeatHierarchy = () => setFeatureFlag(BEAT_HIERARCHY_FLAG)
 
 export const unsetBeatHierarchy = () => unsetFeatureFlag(BEAT_HIERARCHY_FLAG)
 
-export const loadFeatureFlags = (patching, featureFlags) => ({
+export const load = (patching, featureFlags) => ({
   type: LOAD_FEATURE_FLAGS,
   patching,
   featureFlags,

--- a/v2/middlewares/externalSync.js
+++ b/v2/middlewares/externalSync.js
@@ -22,6 +22,13 @@ const externalSync = (patch, withData) => (store) => (next) => (action) => {
         key === 'editors'
       )
         return
+      if (
+        key === 'file' &&
+        present.project.selectedFile &&
+        present.project.selectedFile.permision !== 'owner'
+      ) {
+        return
+      }
       if (action.patching || action.type === 'FILE_LOADED') return
       if (!isEqual(previous[key], present[key])) {
         const payload = withData(key, present[key])

--- a/v2/reducers/cards.js
+++ b/v2/reducers/cards.js
@@ -269,7 +269,10 @@ const cards =
           // see ../selectors/customAttributes.js for when this is allowed
           if (action.oldAttribute.type === 'text') {
             let description = newCard[action.newAttribute.name]
-            if (description && description.length && typeof description !== 'string') {
+            if (
+              !description ||
+              (description && description.length && typeof description !== 'string')
+            ) {
               description = ''
             }
             newCard[action.newAttribute.name] = description

--- a/v2/selectors/editors.js
+++ b/v2/selectors/editors.js
@@ -1,2 +1,2 @@
 export const selectionSelector = (state, path) =>
-  state.editors[path] || { anchor: { path: [0, 0], offset: 0 }, focus: { path: [0, 0], offset: 0 } }
+  state.editors[path] || { anchor: null, focus: null }


### PR DESCRIPTION
# Upstream Changes from Plottr Web
 - Fix the name of the load action for feature flags.
 - Don't try to change the file record when we don't own the file.
 - Default card descriptions to the empty string.
 - Default the anchor and focus to null when an editor has no selection.